### PR TITLE
validator: match type in bool error message

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -630,7 +630,7 @@ class Validator {
     }
 
     if (!this.loose)
-      throw new ValidationError(key, 'hash');
+      throw new ValidationError(key, 'boolean');
 
     if (value === 'true' || value === '1')
       return true;


### PR DESCRIPTION
when passing an invalid bool, error message was:

```
{
  "error": {
    "type": "ValidationError",
    "message": "sort must be a hash."
  }
}
```

fixed error message to say `boolean`