### PR TITLE
hash: better validation error

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -496,7 +496,7 @@ class Validator {
     }
 
     if (value.length !== 64)
-      throw new ValidationError(key, 'hex string');
+      throw new ValidationError(key, 'hash');
 
     if (!/^[0-9a-f]+$/i.test(value))
       throw new ValidationError(key, 'hex string');


### PR DESCRIPTION
I was getting "should be a hex string" errors when passing a hex string, until I realized I wasn't passing the complete 32-byte hash. This PR updates the error so bad input is better identified as a bad hash, not a bad hex string.