### PR TITLE
validator: child fallback

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -58,8 +58,8 @@ class Validator {
    * @returns {Validator}
    */
 
-  child(key) {
-    return new this.constructor(this.get(key));
+  child(key, fallback) {
+    return new this.constructor(this.get(key, fallback));
   }
 
   /**
@@ -883,8 +883,8 @@ class MultiValidator {
     return SENTINEL;
   }
 
-  child(key) {
-    return this.find(key).child(key);
+  child(key, fallback) {
+    return this.find(key).child(key, fallback);
   }
 
   has(key) {


### PR DESCRIPTION
If `child` is called with a non-existent key, it throws an error. This would allow a fallback value to be passed into the child `Validator` that is created instead of allowing it to error out.